### PR TITLE
Add ability to override notify

### DIFF
--- a/cloudcompose/datadog/monitoring/datadogcontroller.py
+++ b/cloudcompose/datadog/monitoring/datadogcontroller.py
@@ -86,7 +86,10 @@ class DatadogController:
         if cluster_prefix:
             monitor['name'] = '[{}] {}'.format(self.cluster_name, monitor.get('name'))
 
-        notified = self.config_data.get('notify', [''])
+        notified = monitor.get('notify', [])
+        if not len(notified):
+           notified = self.config_data.get('notify', [])
+
         monitor['message'] = '{} {}'.format(monitor.get('message'), ' '.join(notified))
 
         # monitor['options'] = {}


### PR DESCRIPTION
## What changed?

Let users override notify at the monitor level.

## How was this tested?

Ran locally with an override config like:

```yaml
datadog:
  name: klondike
  use_cluster_prefix: false
  notify:
    - '@slack-alerts @slack-cool-people'
  monitors:
    -
      tag: sentinel-basic-deploy-failure
      message: "The sentinel for the basic deploy task is failing to deploy."
      name: "sentinel: basic deploy failure"
      query: 'min(last_30m):max:sentinel.basic_deploy.deploy.failure{*} > 0'
    -
      tag: sentinel-simple-load-balancer-provision-failure
      message: "The sentinel for the simple load balancer task is failing to provision."
      name: "sentinel: simple load balancer provision failure"
      query: 'min(last_30m):max:sentinel.simple_load_balancer.provision.failure{*} > 0'
      notify:
        - '@slack-alerts'
```